### PR TITLE
Adding DFLib Java DataFrame to comparison

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ apply plugin: 'java'
 apply plugin: 'kotlin'
 apply plugin: 'eclipse'
 
-sourceCompatibility = 1.8
+sourceCompatibility = 11
 
 repositories {
   mavenCentral()
@@ -39,5 +39,7 @@ dependencies {
 
   implementation "org.jetbrains.kotlinx:dataframe:0.10.0"
   implementation 'org.duckdb:duckdb_jdbc:0.8.0'
+
+  implementation 'org.dflib:dflib-csv:1.1.0'
 }
 

--- a/src/main/java/test_dataframes/TestDFLib.java
+++ b/src/main/java/test_dataframes/TestDFLib.java
@@ -1,0 +1,69 @@
+package test_dataframes;
+
+import com.google.common.base.Stopwatch;
+import org.apache.commons.csv.CSVFormat;
+import org.dflib.DataFrame;
+import org.dflib.Printers;
+import org.dflib.ValueMapper;
+import org.dflib.csv.Csv;
+import org.dflib.print.Printer;
+
+import static org.dflib.Exp.*;
+
+/**
+ * Test the API of tablesaw to do some basic dataframe manipulations.
+ * <p>
+ * https://github.com/dflib/dflib
+ * <p>
+ * See https://medium.com/@thijser/doing-cool-data-science-in-java-how-3-dataframe-libraries-stack-up-5e6ccb7b437
+ * for more information.
+ */
+public class TestDFLib {
+    public static void main(String[] args) {
+
+        Printer printer = Printers.tabular(10, 100);
+
+        DataFrame data = Csv.loader()
+                .format(CSVFormat.DEFAULT.builder().setNullString(":").build())
+                .col("Value", ValueMapper.stringToInt())
+                .load("urb_cpop1_1_Data.csv");
+        System.out.println(printer.toString(data));
+
+        Stopwatch watch = Stopwatch.createStarted();
+        DataFrame filtered = data.rows($col("Value").isNotNull()).select();
+
+        DataFrame cities = filtered.group("CITIES", "INDIC_UR", "TIME")
+                .cols("CITIES", "INDIC_UR", "TIME", "Mean [Value]")
+                .agg($col("CITIES"), $col("INDIC_UR"), $col("TIME"), $int("Value").avg().castAsInt());
+
+        System.out.println(printer.toString(cities));
+
+        // Need to transpose/pivot now too
+        DataFrame finalTable = cities
+                .cols("key").merge(concat($str("CITIES"), ":", $str("INDIC_UR")))
+                .pivot().rows("key").cols("TIME").vals("Mean [Value]");
+
+        // sortDescendingOn puts N/A values first unfortunately, so let's remove them
+        // before determining and printing.
+        DataFrame existing2017 = finalTable
+                .rowsExcept($int("2017").isNull()).select()
+                .rows($str("key").endsWith("January, total")).select()
+                .sort($int("2017").desc());
+        System.out.println(printer.toString(existing2017));
+
+        // Add growth column
+
+        DataFrame finalTable1 = finalTable
+                .cols("growth").merge($int("2016").castAsDouble().div($int("2010")).sub(1).mul(100));
+
+        DataFrame highestGrowthTable = finalTable1
+                .rows($str("key").endsWith("January, total")).select()
+                .rowsExcept($col("growth").isNull()).select()
+                .sort($double("growth").desc());
+
+        System.out.println(printer.toString(highestGrowthTable));
+        CheckResult.checkResult(highestGrowthTable.getColumn("key").toList());
+
+        System.out.println("Total time: " + watch);
+    }
+}


### PR DESCRIPTION
Hi @mathijs81 , 

Found your [Java DataFrame comparison](https://medium.com/@thijser/doing-cool-data-science-in-java-how-3-dataframe-libraries-stack-up-5e6ccb7b437) blog recently. It is a pretty cool comparison, and I wanted to add one more contender : [DFLib](https://github.com/dflib/dflib) 🙂

DFLib is pure Java and provides immutable DataFrames and nice fluent transformations API (and Jupyter integration, and charts, etc.). While Tablesaw and Joinery seem dormant, DFLib is a very active project. This PR is based on the last public release (1.1.0). In 2.0, CSV loading will become speedier, once we switch away from Apache `commons-csv`, so the benchmark should become even better. But even with the slower CSV loader, DFLib is *much* faster than Tablesaw. In my test it was `409.3` (TS) vs `153.3` (DFLib).

I can't fully build the `master` branch because of the specific `joinery` and `krangl` dependencies missing on Maven Central. But if you already have them locally, my PR should work for you. As far as the build goes, it switches Java to 11 (minimal DFLib requirement) and adds a single dependency. 

Would be great to see what numbers you end up with for DFLib on your side 🙂 

